### PR TITLE
fix build with Java 9

### DIFF
--- a/default.build.properties
+++ b/default.build.properties
@@ -12,6 +12,6 @@ ruby.classes.dir=${classes.dir}/ruby
 docs.dir=docs
 api.docs.dir=${docs.dir}/api
 release.dir=rels
-javac.version=1.5
+javac.version=1.7
 ruby.src.dir=ext/ruby/src/java
 jruby.lib=../jruby/lib

--- a/ext/ruby/src/java/YechtService.java
+++ b/ext/ruby/src/java/YechtService.java
@@ -10,6 +10,7 @@ import org.jruby.runtime.load.BasicLibraryService;
 
 import org.yecht.YAML;
 import org.yecht.ruby.*;
+import org.yecht.ruby.Module;
 
 public class YechtService implements BasicLibraryService {
     public boolean basicLoad(final Ruby runtime) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,15 @@
     <sourceDirectory>${basedir}/src/main</sourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>1.8</version>


### PR DESCRIPTION
Java 9 has:

 * dropped support for source level 1.5, so we must specify higher. I picked 1.7.
 * Introduced a `java.lang.Module`, so explicit imports must be used for colliding class names.

(This project looks kinda abandoned, but it's still a build dep of `jruby` in Debian, so here I am.)